### PR TITLE
Workaround for C#

### DIFF
--- a/src/hxparse/Parser.hx
+++ b/src/hxparse/Parser.hx
@@ -29,7 +29,8 @@ class Parser<S:TokenSource<Token>, Token> {
 		Returns the `n`th token without consuming it.
 	**/
 	@:dox(show)
-	inline function peek(n:Int):Token {
+	#if cs inline #end // Workaround for https://github.com/HaxeFoundation/haxe/issues/3212
+	function peek(n:Int):Token {
 		if (token == null) {
 			token = new haxe.ds.GenericStack.GenericCell<Token>(stream.token(), null);
 			n--;


### PR DESCRIPTION
This patch suppresses the following error on C# platform

```
$ haxe haxeparser.HaxeParser -cs cs -dce no -lib haxeparser -lib hxparse -D dll
haxelib run hxcs hxcs_build.txt --haxe-version 3200
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(50,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(66,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(69,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(128,16): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(408,40): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(434,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(434,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(440,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(490,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(492,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(492,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(513,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(513,51): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(522,52): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(531,59): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,66): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(544,60): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(513,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(513,49): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(522,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,48): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(531,57): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,64): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(544,58): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(567,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(592,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(604,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(604,49): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(623,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(659,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(659,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,40): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(716,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(720,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(755,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(762,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(785,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(808,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(833,40): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,40): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(843,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(868,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(869,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,40): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,48): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(880,52): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(880,56): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,60): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,61): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(907,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(907,54): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,62): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(945,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(980,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(981,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(987,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(999,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1063,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1065,49): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1108,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1150,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1168,54): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1175,48): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1177,52): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1186,49): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1186,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,49): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1211,55): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1211,59): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1214,55): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1214,59): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,63): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,67): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,67): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,65): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,65): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1230,55): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1230,59): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,56): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,61): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,65): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1234,56): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1234,60): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1183,50): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1185,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1186,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1186,51): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1211,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1211,57): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1214,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1214,57): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,61): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,65): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,65): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,63): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1218,63): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1230,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1230,57): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,54): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,59): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1233,63): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1234,54): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1234,58): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1254,45): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1267,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1271,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,48): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,53): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1295,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1299,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1299,41): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1313,42): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1313,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1331,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1341,46): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1357,43): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,47): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1359,51): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,36): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\hxparse\git\src\hxparse\ParserBuilderImpl.hx(109,37): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(950,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(949,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(948,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(947,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(946,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1256,38): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1301,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1301,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1301,39): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
d:\HaxeToolkit\haxe\lib\haxeparser\git\src\haxeparser\HaxeParser.hx(1301,44): error CS0266: 无法将类型“object”隐式转换为“haxeparser.Token”。存在一个显式转换(是否缺少强制转换?)
Compilation error
Native compilation failed
Error: Build failed
```
