### PR TITLE
Match output of Position.format with Haxe error

### DIFF
--- a/src/hxparse/Position.hx
+++ b/src/hxparse/Position.hx
@@ -77,7 +77,7 @@ class Position {
 		if (linePos.lineMin != linePos.lineMax) {
 			return '${psource}:lines ${linePos.lineMin}-${linePos.lineMax}';
 		} else {
-			return '${psource}:${linePos.lineMin}:characters ${linePos.posMin}-${linePos.posMax}';
+			return '${psource}:${linePos.lineMin}: characters ${linePos.posMin}-${linePos.posMax}';
 		}
 	}
 


### PR DESCRIPTION
In Haxe, when error occurs, there is space before the `characters` word in position output, so I think it makes more sense for Hxparse to output position info with same format.