### PR TITLE
Support both decimal and hexadecimal escape sequences

### DIFF
--- a/src/hxparse/LexEngine.hx
+++ b/src/hxparse/LexEngine.hx
@@ -333,8 +333,12 @@ class LexEngine {
 	static function parseInner( pattern : byte.ByteData, i : Int = 0, pDepth : Int = 0 ) : { pattern: Pattern, pos: Int } {
 		function readChar() {
 			var c = pattern.readByte(i++);
-			if ( StringTools.isEof(c) ) c = '\\'.code;
-			else if (c >= "0".code && c <= "9".code) {
+			if ( StringTools.isEof(c) ) {
+				c = '\\'.code;
+			} else if (c == "x".code) {
+				c = Std.parseInt("0x" + pattern.readString(i, 2));
+				i += 2;
+			} else if (c >= "0".code && c <= "9".code) {
 				var v = c - 48;
 				while(true) {
 					var cNext = pattern.readByte(i);

--- a/test/UnicodeTestLexer.hx
+++ b/test/UnicodeTestLexer.hx
@@ -18,7 +18,9 @@ class UnicodeTestLexer extends Lexer implements RuleBuilder {
 		'\u00CA' => lexer.current, // Ê
 		'\u20AC' => lexer.current,	// €
 		'\u{29e3d}' => lexer.current, // 𩸽
-		'[ a-zA-Z0-9ÀÁÂÃÄÅÆÇÈÉËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáãäåæçèéëìíîïðñòóôõöøúûüýþÿ№あ𠀀]' => lexer.current,
+		'[ a-zA-Z0-9ÀÁÂÔÕÖØÙÚÛÜÝÞßàáãäåæçèéëìíîïðñòóôõöøúûüýþÿ№あ𠀀]' => lexer.current,
+		'\\195[\\131-\\139]' => lexer.current,
+		'\\xC3[\\x8c-\\x93]' => lexer.current,
 		//'[Ã-Ë]' => lexer.current
 	];
 


### PR DESCRIPTION
This is the evolution of #46, and it is useful for dealing with multi-byte utf-8 chars, particularly when using excluding ranges.

Patterns like the following are now supported:

```
"\\226\\128[\\92-\\95]" => ...
"[^\\226\\128]" => ...
"\\xE2\\x80[\\x5C-\\x5F]" => ...
"[^\\xE2\\x80]" => ...
```